### PR TITLE
Fix: ArgumentError (negative argument) if message is shorter than titles

### DIFF
--- a/lib/tty/box.rb
+++ b/lib/tty/box.rb
@@ -214,6 +214,8 @@ module TTY
       # infer dimensions
       dimensions = infer_dimensions(lines, padding)
       width ||= left_size + dimensions[0] + right_size
+      width = [width, top_space_taken(title, border), bottom_space_taken(title, border)].max
+
       height ||= top_size + dimensions[1] + bottom_size
       content = format(str, width, padding, align) # adjust content
       # infer styling
@@ -306,33 +308,98 @@ module TTY
       [fg, bg]
     end
 
+    # Top space taken by titles and corners
+    #
+    # @return [Integer]
+    #
+    # @api private
+    def top_space_taken(title, border)
+      top_titles_size(title) + top_left_corner(border).size + top_right_corner(border).size
+    end
+
+    # Top left corner
+    #
+    # @return [String]
+    #
+    # @api private
+    def top_left_corner(border)
+      border.top_left? && border.left? ? send(:"#{border.top_left}_char", border.type) : ""
+    end
+
+    # Top right corner
+    #
+    # @return [String]
+    #
+    # @api private
+    def top_right_corner(border)
+      border.top_right? && border.right? ? send(:"#{border.top_right}_char", border.type) : ""
+    end
+
+    # Top titles size
+    #
+    # @return [Integer]
+    #
+    # @api private
+    def top_titles_size(title)
+      title[:top_left].to_s.size + title[:top_center].to_s.size + title[:top_right].to_s.size
+    end
+
     # Top border
     #
     # @return [String]
     #
     # @api private
     def top_border(title, width, border, style)
-      top_titles_size = title[:top_left].to_s.size +
-                        title[:top_center].to_s.size +
-                        title[:top_right].to_s.size
       fg, bg = *extract_style(style[:border] || {})
 
-      top_left = border.top_left? && border.left? ? send(:"#{border.top_left}_char", border.type) : ""
-      top_right = border.top_right? && border.right? ? send(:"#{border.top_right}_char", border.type) : ""
-
-      top_space_left   = width - top_titles_size - top_left.size - top_right.size
+      top_space_left = width - top_space_taken(title, border)
       top_space_before = top_space_left / 2
       top_space_after  = top_space_left / 2 + top_space_left % 2
 
       [
-        bg.(fg.(top_left)),
+        bg.(fg.(top_left_corner(border))),
         bg.(fg.(title[:top_left].to_s)),
         bg.(fg.(line_char(border.type) * top_space_before)),
         bg.(fg.(title[:top_center].to_s)),
         bg.(fg.(line_char(border.type) * top_space_after)),
         bg.(fg.(title[:top_right].to_s)),
-        bg.(fg.(top_right))
+        bg.(fg.(top_right_corner(border)))
       ].join('')
+    end
+    # Bottom space taken by titles and corners
+    #
+    # @return [Integer]
+    #
+    # @api private
+    def bottom_space_taken(title, border)
+      bottom_titles_size(title) + bottom_left_corner(border).size + bottom_right_corner(border).size
+    end
+
+    # Bottom left corner
+    #
+    # @return [String]
+    #
+    # @api private
+    def bottom_left_corner(border)
+      border.bottom_left? && border.left? ? send(:"#{border.bottom_left}_char", border.type) : ""
+    end
+
+    # Bottom right corner
+    #
+    # @return [String]
+    #
+    # @api private
+    def bottom_right_corner(border)
+      border.bottom_right? && border.right? ? send(:"#{border.bottom_right}_char", border.type) : ""
+    end
+
+    # Bottom titles size
+    #
+    # @return [Integer]
+    #
+    # @api private
+    def bottom_titles_size(title)
+      title[:bottom_left].to_s.size + title[:bottom_center].to_s.size + title[:bottom_right].to_s.size
     end
 
     # Bottom border
@@ -341,27 +408,20 @@ module TTY
     #
     # @api private
     def bottom_border(title, width, border, style)
-      bottom_titles_size = title[:bottom_left].to_s.size +
-                           title[:bottom_center].to_s.size +
-                           title[:bottom_right].to_s.size
       fg, bg = *extract_style(style[:border] || {})
 
-      bottom_left  = border.bottom_left? && border.left? ? send(:"#{border.bottom_left}_char", border.type) : ""
-      bottom_right = border.bottom_right? && border.right? ? send(:"#{border.bottom_right}_char", border.type) : ""
-
-      bottom_space_left = width - bottom_titles_size -
-                          bottom_left.size - bottom_right.size
+      bottom_space_left = width - bottom_space_taken(title, border)
       bottom_space_before = bottom_space_left / 2
       bottom_space_after = bottom_space_left / 2 + bottom_space_left % 2
 
       [
-        bg.(fg.(bottom_left)),
+        bg.(fg.(bottom_left_corner(border))),
         bg.(fg.(title[:bottom_left].to_s)),
         bg.(fg.(line_char(border.type) * bottom_space_before)),
         bg.(fg.(title[:bottom_center].to_s)),
         bg.(fg.(line_char(border.type) * bottom_space_after)),
         bg.(fg.(title[:bottom_right].to_s)),
-        bg.(fg.(bottom_right))
+        bg.(fg.(bottom_right_corner(border)))
       ].join('')
     end
   end # TTY

--- a/spec/unit/title_spec.rb
+++ b/spec/unit/title_spec.rb
@@ -34,4 +34,30 @@ RSpec.describe TTY::Box, ':title option' do
       "\e[4;1H└left─────────center─────────right┘"
     ].join)
   end
+
+  it "allows the top title to be longer than the message" do
+    output = TTY::Box.frame("BOO!",
+                            title: {
+                              top_left: " ⚠ WARNING ",
+                            })
+
+    expect(output).to eq([
+      "┌ ⚠ WARNING ┐\n",
+      "│BOO!       │\n",
+      "└───────────┘\n"
+    ].join)
+  end
+
+  it "allows the bottom title to be longer than the message" do
+    output = TTY::Box.frame("BOO!",
+                            title: {
+                              bottom_left: " ⚠ WARNING "
+                            })
+
+    expect(output).to eq([
+      "┌───────────┐\n",
+      "│BOO!       │\n",
+      "└ ⚠ WARNING ┘\n"
+    ].join)
+  end
 end


### PR DESCRIPTION
### Describe the change

It fixes the following bug:
```
> TTY::Box.error('BOO!')
Traceback (most recent call last):
        4: from /home/daniel/.rvm/gems/ruby-2.6.0/gems/tty-box-0.5.0/lib/tty/box.rb:165:in `error'
        3: from /home/daniel/.rvm/gems/ruby-2.6.0/gems/tty-box-0.5.0/lib/tty/box.rb:225:in `frame'
        2: from /home/daniel/.rvm/gems/ruby-2.6.0/gems/tty-box-0.5.0/lib/tty/box.rb:330:in `top_border'
        1: from /home/daniel/.rvm/gems/ruby-2.6.0/gems/tty-box-0.5.0/lib/tty/box.rb:330:in `*'
ArgumentError (negative argument)
```

More broadly this execption is raised every time a message is shorter than the length of all titles and corners in either top or bottom.

To me `TTY::Box.error('BOO!')` was the most obvious way to show off TTY toolkits to my colleague, imagine my embarrasment when it failed with an exception, i.e. I was very much motivated to fix the bug :-)


### Benefits

Bug will no longer be there.

### Drawbacks

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with master branch?
[n/a] Documentaion updated?
