### PR TITLE
Upgrade pastel version to 0.8+

### DIFF
--- a/tty-box.gemspec
+++ b/tty-box.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.0.0"
 
-  spec.add_dependency "pastel", "~> 0.7.2"
+  spec.add_dependency "pastel", "~> 0.8"
   spec.add_dependency "tty-cursor", "~> 0.7"
   spec.add_dependency "strings", "~> 0.1.6"
 


### PR DESCRIPTION
### Describe the change
Allows to use the gem with the newer version of `pastel`

### Why are we doing this?
A fix to `Pastel#strip` has recently introduced which is needed in some apps

### Benefits


### Drawbacks


### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[n/a] Documentaion updated?
