### PR TITLE
Ensure content_size is always positive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
-
+.idea/
 # rspec failure tracking
 .rspec_status


### PR DESCRIPTION
This fixes: `ArgumentError: negative argument` error when supplying multi-line color box contents.

It appears that some of the styling fixes made it into the PR, if it's really important I can remove them.

### Describe the change
Ensures content size is non-negative before it's used in string multiplication

### Why are we doing this?
See https://github.com/kigster/simple-feed/runs/1059350527?check_suite_focus=true#step:5:948

### Benefits
No more explosions

### Drawbacks
None

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[N/A] Documentaion updated?

[fixes #15]